### PR TITLE
Make big-text compatible with strict mode

### DIFF
--- a/big-text.js
+++ b/big-text.js
@@ -81,7 +81,7 @@ function _calculateInnerDimensions(computedStyle){
 	return obj;
 }
 
-BigText = function(element, options){
+var BigText = function(element, options){
 
 	if (typeof element === 'string') {
 		element = document.querySelector(element);


### PR DESCRIPTION
This PR adds support for users of this library which have [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) enabled.